### PR TITLE
Strip Minecraft Color Codes (§) in BasicIO-NoColor mode (#995)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@
 /Other/
 /.vs/
 SessionCache.ini
+.*

--- a/MinecraftClient/ChatBot.cs
+++ b/MinecraftClient/ChatBot.cs
@@ -240,7 +240,7 @@ namespace MinecraftClient
         /// <summary>
         /// Remove color codes ("§c") from a text message received from the server
         /// </summary>
-        protected static string GetVerbatim(string text)
+        public static string GetVerbatim(string text)
         {
             if ( String.IsNullOrEmpty(text) )
                 return String.Empty;

--- a/MinecraftClient/ConsoleIO.cs
+++ b/MinecraftClient/ConsoleIO.cs
@@ -56,6 +56,11 @@ namespace MinecraftClient
         public static bool BasicIO = false;
 
         /// <summary>
+        /// Determines whether not to print color codes in BasicIO mode.
+        /// </summary>
+        public static bool BasicIO_NoColor = false;
+
+        /// <summary>
         /// Determine whether WriteLineFormatted() should prepend lines with timestamps by default.
         /// </summary>
         public static bool EnableTimestamps = false;
@@ -336,6 +341,10 @@ namespace MinecraftClient
                 }
                 if (BasicIO)
                 {
+                    if (BasicIO_NoColor)
+                    {
+                        str = ChatBot.GetVerbatim(str);
+                    }
                     Console.WriteLine(str);
                     return;
                 }

--- a/MinecraftClient/Program.cs
+++ b/MinecraftClient/Program.cs
@@ -59,8 +59,12 @@ namespace MinecraftClient
 
             //Setup ConsoleIO
             ConsoleIO.LogPrefix = "§8[MCC] ";
-            if (args.Length >= 1 && args[args.Length - 1] == "BasicIO")
+            if (args.Length >= 1 && args[args.Length - 1] == "BasicIO" || args.Length >= 1 && args[args.Length - 1] == "BasicIO-NoColor")
             {
+                if (args.Length >= 1 && args[args.Length - 1] == "BasicIO-NoColor")
+                {
+                    ConsoleIO.BasicIO_NoColor = true;
+                }
                 ConsoleIO.BasicIO = true;
                 args = args.Where(o => !Object.ReferenceEquals(o, args[args.Length - 1])).ToArray();
             }


### PR DESCRIPTION
Strip Minecraft color codes and formatting (§) if in BasicIO mode by using BasicIO-NoColor.